### PR TITLE
chore: add terraform module skeletons for infra

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,9 @@
+Terraform modules and example manifests for the ace-tests application.
+
+Structure:
+- modules/: reusable modules (ecr, alb, ecs_fargate_service, rds, s3_site, cloudfront, iam, monitoring)
+- environments/: example environment wiring (production)
+- examples/: example tfvars and usage
+- root/terraform-backend.tf: remote state backend config (example)
+
+IMPORTANT: Replace placeholder values (subnet IDs, SG IDs, ARNs, secrets) before running terraform apply. Use Secrets Manager/SSM for sensitive values.

--- a/infra/terraform/bootstrap/terraform.tfvars
+++ b/infra/terraform/bootstrap/terraform.tfvars
@@ -1,0 +1,5 @@
+{
+  "backend_bucket": "ace-tests-frontend-tfstate-af88104b",
+  "backend_lock_table": "ace-tests-frontend-tfstate-locks-af88104b",
+  "region": "us-east-1"
+}

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -1,0 +1,59 @@
+provider "aws" { region = var.aws_region }
+
+variable "aws_region" { type = string; default = "us-east-1" }
+variable "subnets" { type = list(string); default = ["subnet-PLACEHOLDER1","subnet-PLACEHOLDER2"] }
+variable "security_groups" { type = list(string); default = ["sg-PLACEHOLDER"] }
+variable "db_username" { type = string; default = "dbadmin" }
+variable "db_password" { type = string; sensitive = true }
+
+module "ecr_backend" {
+  source = "../../modules/ecr"
+  repository_name = "ace-tests-backend"
+  tags = { Environment = "production"; App = "ace-tests-backend" }
+}
+
+module "alb" {
+  source = "../../modules/alb"
+  load_balancer_name = "ace-tests-backend-alb"
+  subnets = var.subnets
+  security_groups = var.security_groups
+}
+
+module "ecs_backend" {
+  source = "../../modules/ecs_fargate_service"
+  cluster_name = "ace-tests-backend-cluster"
+  service_name = "ace-tests-backend-service"
+  image = module.ecr_backend.repository_url
+  container_port = 3000
+  subnets = var.subnets
+  security_groups = var.security_groups
+  desired_count = 2
+  assign_public_ip = "DISABLED"
+  execution_role_arn = ""
+}
+
+module "db" {
+  source = "../../modules/rds"
+  engine = "mysql"
+  allocated_storage = 20
+  instance_class = "db.t3.micro"
+  name = "ace_tests_db"
+  username = var.db_username
+  password = var.db_password
+  publicly_accessible = false
+}
+
+module "frontend_bucket" {
+  source = "../../modules/s3_site"
+  bucket_name = "ace-tests-frontend-site-production"
+  enable_versioning = true
+  enable_encryption = true
+}
+
+module "frontend_cloudfront" {
+  source = "../../modules/cloudfront"
+  origin_bucket_domain_name = module.frontend_bucket.bucket_domain_name
+  alternative_domain_names = []
+}
+
+output "frontend_site_url" { value = module.frontend_cloudfront.distribution_domain_name }

--- a/infra/terraform/examples/README.md
+++ b/infra/terraform/examples/README.md
@@ -1,0 +1,1 @@
+This folder contains example Terraform variable files and manifests to illustrate how to deploy the recommended architecture using the modular Terraform setup. Replace placeholder values with real AWS resource identifiers and credentials. The two-phase bootstrap pattern for Terraform remote state is referenced in the main deployment docs.

--- a/infra/terraform/examples/terraform.tfvars.json
+++ b/infra/terraform/examples/terraform.tfvars.json
@@ -1,0 +1,9 @@
+{
+  "aws_region": "us-east-1",
+  "subnets": ["subnet-PLACEHOLDER1", "subnet-PLACEHOLDER2"],
+  "security_groups": ["sg-PLACEHOLDER"],
+  "db_username": "dbadmin",
+  "db_password": "CHANGE_ME",
+  "ecr_repository_name": "ace-tests-backend",
+  "frontend_bucket_name": "ace-tests-frontend-site-production"
+}

--- a/infra/terraform/modules/alb/main.tf
+++ b/infra/terraform/modules/alb/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "load_balancer_name" { type = string }
+variable "subnets" { type = list(string) }
+variable "security_groups" { type = list(string); default = [] }
+
+data "aws_vpc" "default" { default = true }
+
+resource "aws_lb" "this" {
+  name               = var.load_balancer_name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = var.security_groups
+  subnets            = var.subnets
+}
+
+resource "aws_lb_target_group" "this" {
+  name     = "${var.load_balancer_name}-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = data.aws_vpc.default.id
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+output "alb_dns_name" { value = aws_lb.this.dns_name }
+output "alb_arn" { value = aws_lb.this.arn }
+output "alb_target_group_arn" { value = aws_lb_target_group.this.arn }

--- a/infra/terraform/modules/alb/outputs.tf
+++ b/infra/terraform/modules/alb/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_dns_name" { value = aws_lb.this.dns_name }
+output "alb_arn" { value = aws_lb.this.arn }
+output "alb_target_group_arn" { value = aws_lb_target_group.this.arn }

--- a/infra/terraform/modules/alb/variables.tf
+++ b/infra/terraform/modules/alb/variables.tf
@@ -1,0 +1,3 @@
+variable "load_balancer_name" { type = string }
+variable "subnets" { type = list(string) }
+variable "security_groups" { type = list(string); default = [] }

--- a/infra/terraform/modules/cloudfront/main.tf
+++ b/infra/terraform/modules/cloudfront/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "origin_bucket_domain_name" { type = string }
+variable "alternative_domain_names" { type = list(string); default = [] }
+
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "OAI for S3 site"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled = true
+  origins {
+    domain_name = var.origin_bucket_domain_name
+    origin_id   = "s3-site-origin"
+    s3_origin_config { origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path }
+  }
+
+  enabled                   = true
+  is_ipv6_enabled           = true
+  default_root_object       = "index.html"
+
+  default_cache_behavior {
+    target_origin_id       = "s3-site-origin"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+  }
+
+  price_class = "PriceClass_All"
+
+  viewer_certificate { cloudfront_default_certificate = true }
+}
+
+output "distribution_domain_name" { value = aws_cloudfront_distribution.this.domain_name }
+output "distribution_id" { value = aws_cloudfront_distribution.this.id }

--- a/infra/terraform/modules/cloudfront/outputs.tf
+++ b/infra/terraform/modules/cloudfront/outputs.tf
@@ -1,0 +1,2 @@
+output "distribution_domain_name" { value = aws_cloudfront_distribution.this.domain_name }
+output "distribution_id" { value = aws_cloudfront_distribution.this.id }

--- a/infra/terraform/modules/cloudfront/variables.tf
+++ b/infra/terraform/modules/cloudfront/variables.tf
@@ -1,0 +1,2 @@
+variable "origin_bucket_domain_name" { type = string }
+variable "alternative_domain_names" { type = list(string); default = [] }

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "repository_name" {
+  description = "Name of the ECR repository"
+  type        = string
+}
+
+variable "tags" {
+  description = "Optional tags for the repository"
+  type        = map(string)
+  default     = {}
+}
+
+resource "aws_ecr_repository" "this" {
+  name                 = var.repository_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = var.tags
+}
+
+output "repository_url" {
+  value = aws_ecr_repository.this.repository_url
+}
+output "repository_name" {
+  value = aws_ecr_repository.this.name
+}
+output "repository_arn" {
+  value = aws_ecr_repository.this.arn
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,6 @@
+output "repository_url" {
+  value = aws_ecr_repository.this.repository_url
+}
+output "repository_arn" {
+  value = aws_ecr_repository.this.arn
+}

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,0 +1,10 @@
+variable "repository_name" {
+  description = "ECR repository name"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/ecs_fargate_service/main.tf
+++ b/infra/terraform/modules/ecs_fargate_service/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "cluster_name" { type = string }
+variable "service_name" { type = string }
+variable "image" { type = string }
+variable "container_port" { type = number; default = 3000 }
+variable "subnets" { type = list(string) }
+variable "security_groups" { type = list(string); default = [] }
+variable "desired_count" { type = number; default = 2 }
+variable "assign_public_ip" { type = string; default = "DISABLED" }
+variable "execution_role_arn" { type = string; default = "" }
+
+resource "aws_ecs_cluster" "this" {
+  name = var.cluster_name
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.service_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = var.image
+      essential = true
+      portMappings = [ { containerPort = var.container_port; hostPort = var.container_port; protocol = "tcp" } ]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.service_name
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnets
+    security_groups  = var.security_groups
+    assign_public_ip = var.assign_public_ip
+  }
+
+  depends_on = [aws_ecs_task_definition.this]
+}
+
+output "service_name" { value = aws_ecs_service.this.name }
+output "task_definition_arn" { value = aws_ecs_task_definition.this.arn }
+output "cluster_id" { value = aws_ecs_cluster.this.id }

--- a/infra/terraform/modules/ecs_fargate_service/outputs.tf
+++ b/infra/terraform/modules/ecs_fargate_service/outputs.tf
@@ -1,0 +1,3 @@
+output "service_name" { value = aws_ecs_service.this.name }
+output "task_definition_arn" { value = aws_ecs_task_definition.this.arn }
+output "cluster_id" { value = aws_ecs_cluster.this.id }

--- a/infra/terraform/modules/ecs_fargate_service/variables.tf
+++ b/infra/terraform/modules/ecs_fargate_service/variables.tf
@@ -1,0 +1,9 @@
+variable "cluster_name" { type = string }
+variable "service_name" { type = string }
+variable "image" { type = string }
+variable "container_port" { type = number; default = 3000 }
+variable "subnets" { type = list(string) }
+variable "security_groups" { type = list(string); default = [] }
+variable "desired_count" { type = number; default = 2 }
+variable "assign_public_ip" { type = string; default = "DISABLED" }
+variable "execution_role_arn" { type = string; default = "" }

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "assume_role_policy" { type = string; default = "" }
+
+resource "aws_iam_role" "this" {
+  name               = "terraform-module-role"
+  assume_role_policy = var.assume_role_policy != "" ? var.assume_role_policy : data.aws_iam_policy_document.default.json
+}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    principals { type = "Service"; identifiers = ["ec2.amazonaws.com"] }
+    effect = "Allow"
+    sid    = "ExampleAssumeRole"
+  }
+}
+
+output "role_arn" { value = aws_iam_role.this.arn }

--- a/infra/terraform/modules/iam/outputs.tf
+++ b/infra/terraform/modules/iam/outputs.tf
@@ -1,0 +1,1 @@
+output "role_arn" { value = aws_iam_role.this.arn }

--- a/infra/terraform/modules/iam/variables.tf
+++ b/infra/terraform/modules/iam/variables.tf
@@ -1,0 +1,1 @@
+variable "assume_role_policy" { type = string; default = "" }

--- a/infra/terraform/modules/monitoring/main.tf
+++ b/infra/terraform/modules/monitoring/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "alarm_name" { type = string; default = "HighCPUAlarm" }
+
+resource "aws_cloudwatch_metric_alarm" "cpu" {
+  alarm_name          = var.alarm_name
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  statistic           = "Average"
+  threshold           = 80
+  dimensions = { ClusterName = "PLACEHOLDER_CLUSTER"; ServiceName = "PLACEHOLDER_SERVICE" }
+  alarm_description = "Alarm when ECS task CPU usage exceeds 80%"
+  treat_missing_data = "breaching"
+}
+
+output "alarm_name" { value = aws_cloudwatch_metric_alarm.cpu.alarm_name }

--- a/infra/terraform/modules/monitoring/outputs.tf
+++ b/infra/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,1 @@
+output "alarm_name" { value = aws_cloudwatch_metric_alarm.cpu.alarm_name }

--- a/infra/terraform/modules/monitoring/variables.tf
+++ b/infra/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,1 @@
+variable "alarm_name" { type = string; default = "HighCPUAlarm" }

--- a/infra/terraform/modules/rds/main.tf
+++ b/infra/terraform/modules/rds/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "engine" { type = string; default = "mysql" }
+variable "allocated_storage" { type = number; default = 20 }
+variable "instance_class" { type = string; default = "db.t3.micro" }
+variable "name" { type = string; default = "appdb" }
+variable "username" { type = string; default = "dbadmin" }
+variable "password" { type = string; sensitive = true }
+variable "publicly_accessible" { type = bool; default = false }
+
+resource "aws_db_instance" "this" {
+  allocated_storage    = var.allocated_storage
+  engine               = var.engine
+  instance_class       = var.instance_class
+  name                 = var.name
+  username             = var.username
+  password             = var.password
+  publicly_accessible  = var.publicly_accessible
+  skip_final_snapshot  = true
+  multi_az             = false
+  parameter_group_name = "default.${var.engine}"
+  tags = { Name = var.name }
+}
+
+output "endpoint" { value = aws_db_instance.this.address }
+output "arn" { value = aws_db_instance.this.arn }

--- a/infra/terraform/modules/rds/outputs.tf
+++ b/infra/terraform/modules/rds/outputs.tf
@@ -1,0 +1,2 @@
+output "endpoint" { value = aws_db_instance.this.address }
+output "arn" { value = aws_db_instance.this.arn }

--- a/infra/terraform/modules/rds/variables.tf
+++ b/infra/terraform/modules/rds/variables.tf
@@ -1,0 +1,7 @@
+variable "engine" { type = string; default = "mysql" }
+variable "allocated_storage" { type = number; default = 20 }
+variable "instance_class" { type = string; default = "db.t3.micro" }
+variable "name" { type = string; default = "appdb" }
+variable "username" { type = string; default = "dbadmin" }
+variable "password" { type = string; sensitive = true }
+variable "publicly_accessible" { type = bool; default = false }

--- a/infra/terraform/modules/s3_site/main.tf
+++ b/infra/terraform/modules/s3_site/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+  required_version = ">= 1.5.0"
+}
+
+variable "bucket_name" { type = string }
+variable "enable_versioning" { type = bool; default = true }
+variable "enable_encryption" { type = bool; default = true }
+
+resource "aws_s3_bucket" "site" {
+  bucket = var.bucket_name
+  acl    = "private"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "site" {
+  bucket = aws_s3_bucket.site.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket = aws_s3_bucket.site.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "site" {
+  bucket = aws_s3_bucket.site.id
+  versioning_configuration { status = var.enable_versioning ? "Enabled" : "Disabled" }
+}
+
+output "bucket_domain_name" { value = aws_s3_bucket.site.bucket_domain_name }
+output "bucket_arn" { value = aws_s3_bucket.site.arn }

--- a/infra/terraform/modules/s3_site/outputs.tf
+++ b/infra/terraform/modules/s3_site/outputs.tf
@@ -1,0 +1,2 @@
+output "bucket_domain_name" { value = aws_s3_bucket.site.bucket_domain_name }
+output "bucket_arn" { value = aws_s3_bucket.site.arn }

--- a/infra/terraform/modules/s3_site/variables.tf
+++ b/infra/terraform/modules/s3_site/variables.tf
@@ -1,0 +1,3 @@
+variable "bucket_name" { type = string }
+variable "enable_versioning" { type = bool; default = true }
+variable "enable_encryption" { type = bool; default = true }

--- a/infra/terraform/root/terraform-backend.tf
+++ b/infra/terraform/root/terraform-backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {
+    bucket = "ace-tests-frontend-tfstate-af88104b"
+    key    = "terraform.tfstate"
+    region = "us-east-1"
+    dynamodb_table = "ace-tests-frontend-tfstate-locks-af88104b"
+    encrypt = true
+  }
+  required_providers {
+    aws = { source = "hashicorp/aws"; version = "~> 5.0" }
+  }
+}


### PR DESCRIPTION
Adds Terraform module skeletons and example manifests for ECS Fargate backend and S3+CloudFront frontend. Replace placeholders before apply.