### PR TITLE
fix: terraform CloudFront/RDS HCL fixes

### DIFF
--- a/infra/terraform/examples/terraform.tfvars.json
+++ b/infra/terraform/examples/terraform.tfvars.json
@@ -1,9 +1,11 @@
 {
+  "project_name": "ace-tests-backend",
   "aws_region": "us-east-1",
   "subnets": ["subnet-PLACEHOLDER1", "subnet-PLACEHOLDER2"],
   "security_groups": ["sg-PLACEHOLDER"],
   "db_username": "dbadmin",
   "db_password": "CHANGE_ME",
+  "identifier": "ace-tests-backend-db",
   "ecr_repository_name": "ace-tests-backend",
   "frontend_bucket_name": "ace-tests-frontend-site-production"
 }

--- a/infra/terraform/modules/cloudfront/main.tf
+++ b/infra/terraform/modules/cloudfront/main.tf
@@ -14,6 +14,12 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
   is_ipv6_enabled     = true
   default_root_object = "index.html"
 

--- a/infra/terraform/modules/rds/main.tf
+++ b/infra/terraform/modules/rds/main.tf
@@ -2,12 +2,12 @@ resource "aws_db_instance" "this" {
   allocated_storage    = var.allocated_storage
   engine               = var.engine
   instance_class       = var.instance_class
-  name                 = var.name
+  identifier           = var.identifier
   username             = var.username
   password             = var.password
   publicly_accessible  = var.publicly_accessible
   skip_final_snapshot  = true
   multi_az             = false
   parameter_group_name = "default.${var.engine}"
-  tags = { Name = var.name }
+  tags                 = { Name = var.identifier }
 }

--- a/infra/terraform/modules/rds/main.tf
+++ b/infra/terraform/modules/rds/main.tf
@@ -9,5 +9,7 @@ resource "aws_db_instance" "this" {
   skip_final_snapshot  = true
   multi_az             = false
   parameter_group_name = "default.${var.engine}"
-  tags                 = { Name = var.identifier }
+  tags = {
+    Name = var.identifier
+  }
 }

--- a/infra/terraform/modules/rds/variables.tf
+++ b/infra/terraform/modules/rds/variables.tf
@@ -15,7 +15,7 @@ variable "instance_class" {
 
 variable "identifier" {
   type    = string
-  default = "appdb"
+  default = "ace-tests-backend-db"
 }
 
 variable "username" {

--- a/infra/terraform/modules/rds/variables.tf
+++ b/infra/terraform/modules/rds/variables.tf
@@ -13,7 +13,7 @@ variable "instance_class" {
   default = "db.t3.micro"
 }
 
-variable "name" {
+variable "identifier" {
   type    = string
   default = "appdb"
 }


### PR DESCRIPTION
Adds CloudFront restrictions, RDS identifier fixes, and example tfvars with project_name. Runs terraform fmt/validate/plan.