### PR TITLE
chore(ci): use environment terraform-ci for terraform job

### DIFF
--- a/.github/workflows/infra-terraform.yml
+++ b/.github/workflows/infra-terraform.yml
@@ -19,6 +19,8 @@ permissions:
 
 jobs:
   terraform-ci:
+
+    environment: terraform-ci
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Ensure terraform job uses environment terraform-ci so environment secrets are available.